### PR TITLE
fix(signin): 签到结果校验 + 独立签到设备指纹 + 本机设备ID自动探测

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,40 @@ go build -o tw2api ./cmd/server
 ./credit.sh <uid>       # 指定账号
 ```
 
+## 签到设备ID
+
+签到接口要求请求头携带**独立设备三件套**（`x-device-id` / `x-device-brand` /
+`x-device-type`），与模型通道的 `machineId`/`deviceId` 不是同一组；且**多账号
+必须各不相同**，共用同一设备 ID 会被上游关联。凭证字段为 auth 段的
+`checkinDeviceId` / `checkinDeviceBrand` / `checkinDeviceType`。
+
+**自动获取（默认，推荐）**：`signin.sh` 或自动签到调度器发现凭证缺
+`checkinDeviceId` 时，会自动从**本机已登录的 TRAE SOLO 官方客户端**本地数据
+读取设备标识（macOS / Windows），并写回凭证文件，之后容器内调度器直接复用。
+可用 `TW2A_DISABLE_CHECKIN_DETECT=1` 关闭该探测。
+
+**手动获取**（账号的官方客户端登录在**另一台设备**上时，需到那台设备上取）：
+
+```bash
+# macOS（在那台设备上执行）：
+strings ~/Library/Application\ Support/TRAE\ SOLO\ CN/Local\ Storage/leveldb/*.log \
+  | grep -o '"user_unique_id":"[0-9]*"' | tail -1   # → checkinDeviceId
+sysctl -n hw.model                                   # → checkinDeviceBrand
+# checkinDeviceType 填 "mac"
+```
+
+```powershell
+# Windows PowerShell（在那台设备上执行）：
+Get-ChildItem "$env:APPDATA\TRAE SOLO CN\Local Storage\leveldb" -Include *.log,*.ldb -Recurse |
+  Select-String '"user_unique_id":"(\d+)"' | Select-Object -Last 1  # → checkinDeviceId
+(Get-CimInstance Win32_BaseBoard).Product                            # → checkinDeviceBrand
+# checkinDeviceType 填 "windows"
+```
+
+把三个值填进 `auths/trae-<uid>.json` 的 `auth` 段即可。既无本机客户端、
+凭证也缺字段时，签到会被**明确跳过并打印原因**——不会发无设备头的无效请求，
+也不会生成上游无法识别的随机假 ID。
+
 ## 目录结构
 
 ```

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,6 +64,11 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	// 启动即刷新一次 token + 签到 + 积分，避免 state.json 空时长期显示 0。
+	go func() {
+		sch.RunRefreshNow()
+		sch.RunCheckinNow()
+	}()
 	go sch.Run(ctx)
 
 	srv := &http.Server{

--- a/cmd/signin/main.go
+++ b/cmd/signin/main.go
@@ -75,34 +75,55 @@ func main() {
 		}
 
 		// 签到
-		checkedIn, _, enable, serr := up.CheckinStatus(a)
-		switch {
-		case serr != nil:
-			if isAlready(serr.Error()) {
-				r.status = "ALREADY"
-				r.detail = short(serr.Error())
-				alreadyN++
-			} else {
-				r.status = "FAIL"
-				r.detail = short(serr.Error())
-				failN++
-			}
-		case checkedIn:
-			r.status = "ALREADY"
-			r.detail = "already checked in"
-			alreadyN++
-		case !enable:
+		if a.CheckinDeviceID == "" {
+			// 凭证缺少独立签到设备标识：签到请求必须带与模型通道不同的
+			// 设备标识，且多账号之间必须各不相同（相同会被上游关联）。
+			// 这里明确报 FAIL 并说明原因，不发无设备头的无效请求，
+			// 也不生成随机假 ID（上游无法识别，签到永远不会生效）。
 			r.status = "FAIL"
-			r.detail = "checkin disabled"
+			r.detail = "missing checkinDeviceId: 签到需独立设备ID（多账号须各不相同），请重新导入含 checkinDeviceId/checkinDeviceBrand/checkinDeviceType 的凭证"
 			failN++
-		default:
-			if err := up.CheckinClaim(a); err != nil {
+		} else {
+			checkedIn, _, enable, serr := up.CheckinStatus(a)
+			switch {
+			case serr != nil:
+				if isAlready(serr.Error()) {
+					r.status = "ALREADY"
+					r.detail = short(serr.Error())
+					alreadyN++
+				} else {
+					r.status = "FAIL"
+					r.detail = short(serr.Error())
+					failN++
+				}
+			case checkedIn:
+				r.status = "ALREADY"
+				r.detail = "already checked in"
+				alreadyN++
+			case !enable:
 				r.status = "FAIL"
-				r.detail = short(err.Error())
+				r.detail = "checkin disabled"
 				failN++
-			} else {
-				r.status = "OK"
-				okN++
+			default:
+				if err := up.CheckinClaim(a); err != nil {
+					r.status = "FAIL"
+					r.detail = short(err.Error())
+					failN++
+				} else {
+					verified, _, _, err := up.CheckinStatus(a)
+					if err != nil {
+						r.status = "FAIL"
+						r.detail = "verify: " + short(err.Error())
+						failN++
+					} else if !verified {
+						r.status = "FAIL"
+						r.detail = "verify: status still unchecked"
+						failN++
+					} else {
+						r.status = "OK"
+						okN++
+					}
+				}
 			}
 		}
 		// 查积分

--- a/cmd/signin/main.go
+++ b/cmd/signin/main.go
@@ -37,6 +37,22 @@ func main() {
 	sort.Strings(files)
 	up := upstream.New()
 
+	// 本机官方客户端签到设备标识，懒探测一次，全账号复用。
+	var (
+		detOnce               bool
+		detID, detBrand, detT string
+		detOK                 bool
+	)
+	detect := func() bool {
+		if !detOnce {
+			detID, detBrand, detT, detOK = auth.DetectLocalCheckinDevice()
+			detOnce = true
+		}
+		return detOK
+	}
+	var notes []string
+	idUsers := map[string][]string{} // 签到设备ID → 使用该ID的账号（查多账号共用）
+
 	var rows []row
 	okN, alreadyN, failN := 0, 0, 0
 	for _, f := range files {
@@ -75,15 +91,26 @@ func main() {
 		}
 
 		// 签到
+		if a.CheckinDeviceID == "" && detect() {
+			// 凭证缺独立签到设备标识时，从本机已登录的官方客户端自动读取，
+			// 并写回凭证文件（容器内 scheduler 读不到本机客户端数据，靠落盘共享）。
+			a.CheckinDeviceID, a.CheckinDeviceBrand, a.CheckinDeviceType = detID, detBrand, detT
+			if err := a.SaveAtomic(); err != nil {
+				notes = append(notes, fmt.Sprintf("%s: 自动读取签到设备ID成功但写回凭证失败: %v", r.uid, err))
+			} else {
+				notes = append(notes, fmt.Sprintf("%s: 已从本机官方客户端自动读取签到设备ID并写回凭证", r.uid))
+			}
+		}
 		if a.CheckinDeviceID == "" {
 			// 凭证缺少独立签到设备标识：签到请求必须带与模型通道不同的
 			// 设备标识，且多账号之间必须各不相同（相同会被上游关联）。
 			// 这里明确报 FAIL 并说明原因，不发无设备头的无效请求，
 			// 也不生成随机假 ID（上游无法识别，签到永远不会生效）。
 			r.status = "FAIL"
-			r.detail = "missing checkinDeviceId: 签到需独立设备ID（多账号须各不相同），请重新导入含 checkinDeviceId/checkinDeviceBrand/checkinDeviceType 的凭证"
+			r.detail = "缺签到设备ID且本机未检测到官方客户端，无法自动读取；手动获取见 README「签到设备ID」"
 			failN++
 		} else {
+			idUsers[a.CheckinDeviceID] = append(idUsers[a.CheckinDeviceID], r.uid)
 			checkedIn, _, enable, serr := up.CheckinStatus(a)
 			switch {
 			case serr != nil:
@@ -145,6 +172,16 @@ func main() {
 			trunc(r.uid, 36), trunc(r.nick, 11), r.status, remain, r.detail)
 	}
 	fmt.Printf("\ntotal=%d ok=%d already=%d fail=%d\n", len(rows), okN, alreadyN, failN)
+	for _, n := range notes {
+		fmt.Println("note:", n)
+	}
+	// 多账号共用同一签到设备ID 会被上游关联，明确警告。
+	for _, uids := range idUsers {
+		if len(uids) > 1 {
+			fmt.Printf("WARN: 签到设备ID 被 %d 个账号共用（%s），多账号须各用不同设备ID，否则可能被上游关联\n",
+				len(uids), strings.Join(uids, ", "))
+		}
+	}
 }
 
 // isAlready 已签判定：仅匹配明确表示"今日已签到"的业务错误。

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -22,17 +22,20 @@ import (
 type Auth struct {
 	mu sync.RWMutex
 
-	AccessToken  string // Cloud-IDE-JWT 头用
-	RefreshToken string // 每次 ExchangeToken 轮换
-	ExpiresAt    int64  // Unix 秒（accessToken 过期时刻）
-	Domain       string // "trae.cn"
-	ApiHost      string // "https://api.trae.com.cn"（ExchangeToken host）
-	MachineID    string // x-machine-id
-	DeviceID     string // x-device-id
-	UID          string
-	EnterpriseID string
-	Nickname     string
-	FilePath     string // 落盘路径；refresh 后原子写回
+	AccessToken        string // Cloud-IDE-JWT 头用
+	RefreshToken       string // 每次 ExchangeToken 轮换
+	ExpiresAt          int64  // Unix 秒（accessToken 过期时刻）
+	Domain             string // "trae.cn"
+	ApiHost            string // "https://api.trae.com.cn"（ExchangeToken host）
+	MachineID          string // 模型通道 x-machine-id
+	DeviceID           string // 模型通道 x-device-id
+	CheckinDeviceID    string // 签到 x-device-id
+	CheckinDeviceBrand string // 签到 x-device-brand
+	CheckinDeviceType  string // 签到 x-device-type
+	UID                string
+	EnterpriseID       string
+	Nickname           string
+	FilePath           string // 落盘路径；refresh 后原子写回
 }
 
 // Lock 供同进程内其他包（upstream.RefreshToken）在改写 Auth 字段期间加写锁。
@@ -82,13 +85,16 @@ func (a *Auth) NeedsRefreshLocked(within time.Duration) bool {
 func parseNested(raw []byte) (*Auth, error) {
 	var n struct {
 		Auth struct {
-			AccessToken  string `json:"accessToken"`
-			RefreshToken string `json:"refreshToken"`
-			ExpiresAt    int64  `json:"expiresAt"`
-			Domain       string `json:"domain"`
-			ApiHost      string `json:"apiHost"`
-			MachineID    string `json:"machineId"`
-			DeviceID     string `json:"deviceId"`
+			AccessToken        string `json:"accessToken"`
+			RefreshToken       string `json:"refreshToken"`
+			ExpiresAt          int64  `json:"expiresAt"`
+			Domain             string `json:"domain"`
+			ApiHost            string `json:"apiHost"`
+			MachineID          string `json:"machineId"`
+			DeviceID           string `json:"deviceId"`
+			CheckinDeviceID    string `json:"checkinDeviceId"`
+			CheckinDeviceBrand string `json:"checkinDeviceBrand"`
+			CheckinDeviceType  string `json:"checkinDeviceType"`
 		} `json:"auth"`
 		Account struct {
 			UID          string `json:"uid"`
@@ -100,16 +106,19 @@ func parseNested(raw []byte) (*Auth, error) {
 		return nil, fmt.Errorf("storage_parse_error: %w", err)
 	}
 	return &Auth{
-		AccessToken:  n.Auth.AccessToken,
-		RefreshToken: n.Auth.RefreshToken,
-		ExpiresAt:    n.Auth.ExpiresAt,
-		Domain:       n.Auth.Domain,
-		ApiHost:      n.Auth.ApiHost,
-		MachineID:    n.Auth.MachineID,
-		DeviceID:     n.Auth.DeviceID,
-		UID:          n.Account.UID,
-		EnterpriseID: n.Account.EnterpriseID,
-		Nickname:     n.Account.Nickname,
+		AccessToken:        n.Auth.AccessToken,
+		RefreshToken:       n.Auth.RefreshToken,
+		ExpiresAt:          n.Auth.ExpiresAt,
+		Domain:             n.Auth.Domain,
+		ApiHost:            n.Auth.ApiHost,
+		MachineID:          n.Auth.MachineID,
+		DeviceID:           n.Auth.DeviceID,
+		CheckinDeviceID:    n.Auth.CheckinDeviceID,
+		CheckinDeviceBrand: n.Auth.CheckinDeviceBrand,
+		CheckinDeviceType:  n.Auth.CheckinDeviceType,
+		UID:                n.Account.UID,
+		EnterpriseID:       n.Account.EnterpriseID,
+		Nickname:           n.Account.Nickname,
 	}, nil
 }
 
@@ -118,31 +127,37 @@ func parseNested(raw []byte) (*Auth, error) {
 //	{"accessToken":...,"uid":...,"machineId":...,"deviceId":...}
 func parseFlat(raw []byte) (*Auth, error) {
 	var f struct {
-		AccessToken  string `json:"accessToken"`
-		RefreshToken string `json:"refreshToken"`
-		ExpiresAt    int64  `json:"expiresAt"`
-		Domain       string `json:"domain"`
-		ApiHost      string `json:"apiHost"`
-		MachineID    string `json:"machineId"`
-		DeviceID     string `json:"deviceId"`
-		UID          string `json:"uid"`
-		EnterpriseID string `json:"enterpriseId"`
-		Nickname     string `json:"nickname"`
+		AccessToken        string `json:"accessToken"`
+		RefreshToken       string `json:"refreshToken"`
+		ExpiresAt          int64  `json:"expiresAt"`
+		Domain             string `json:"domain"`
+		ApiHost            string `json:"apiHost"`
+		MachineID          string `json:"machineId"`
+		DeviceID           string `json:"deviceId"`
+		CheckinDeviceID    string `json:"checkinDeviceId"`
+		CheckinDeviceBrand string `json:"checkinDeviceBrand"`
+		CheckinDeviceType  string `json:"checkinDeviceType"`
+		UID                string `json:"uid"`
+		EnterpriseID       string `json:"enterpriseId"`
+		Nickname           string `json:"nickname"`
 	}
 	if err := json.Unmarshal(raw, &f); err != nil {
 		return nil, fmt.Errorf("storage_parse_error: %w", err)
 	}
 	return &Auth{
-		AccessToken:  f.AccessToken,
-		RefreshToken: f.RefreshToken,
-		ExpiresAt:    f.ExpiresAt,
-		Domain:       f.Domain,
-		ApiHost:      f.ApiHost,
-		MachineID:    f.MachineID,
-		DeviceID:     f.DeviceID,
-		UID:          f.UID,
-		EnterpriseID: f.EnterpriseID,
-		Nickname:     f.Nickname,
+		AccessToken:        f.AccessToken,
+		RefreshToken:       f.RefreshToken,
+		ExpiresAt:          f.ExpiresAt,
+		Domain:             f.Domain,
+		ApiHost:            f.ApiHost,
+		MachineID:          f.MachineID,
+		DeviceID:           f.DeviceID,
+		CheckinDeviceID:    f.CheckinDeviceID,
+		CheckinDeviceBrand: f.CheckinDeviceBrand,
+		CheckinDeviceType:  f.CheckinDeviceType,
+		UID:                f.UID,
+		EnterpriseID:       f.EnterpriseID,
+		Nickname:           f.Nickname,
 	}, nil
 }
 
@@ -191,13 +206,16 @@ func (a *Auth) saveAtomicLocked() error {
 	}
 	doc := map[string]any{
 		"auth": map[string]any{
-			"accessToken":  a.AccessToken,
-			"refreshToken": a.RefreshToken,
-			"expiresAt":    a.ExpiresAt,
-			"domain":       a.Domain,
-			"apiHost":      a.ApiHost,
-			"machineId":    a.MachineID,
-			"deviceId":     a.DeviceID,
+			"accessToken":        a.AccessToken,
+			"refreshToken":       a.RefreshToken,
+			"expiresAt":          a.ExpiresAt,
+			"domain":             a.Domain,
+			"apiHost":            a.ApiHost,
+			"machineId":          a.MachineID,
+			"deviceId":           a.DeviceID,
+			"checkinDeviceId":    a.CheckinDeviceID,
+			"checkinDeviceBrand": a.CheckinDeviceBrand,
+			"checkinDeviceType":  a.CheckinDeviceType,
 		},
 		"account": map[string]any{
 			"uid":          a.UID,

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -14,7 +14,8 @@ const existingFormat = `{
   "auth": {
     "accessToken": "at-placeholder", "refreshToken": "rt-placeholder", "expiresAt": 1786805537,
     "domain": "trae.cn", "apiHost": "https://api.trae.com.cn",
-    "machineId": "abcdef0123456789abcdef0123456789", "deviceId": "0123456789abcdef0123456789abcdef"
+    "machineId": "abcdef0123456789abcdef0123456789", "deviceId": "0123456789abcdef0123456789abcdef",
+    "checkinDeviceId": "1111222233334444", "checkinDeviceBrand": "Mac16,10", "checkinDeviceType": "mac"
   }
 }`
 
@@ -35,12 +36,15 @@ func TestParseExistingFormat(t *testing.T) {
 	if len(a.MachineID) != 32 || len(a.DeviceID) != 32 {
 		t.Errorf("ids: machine=%q device=%q", a.MachineID, a.DeviceID)
 	}
+	if a.CheckinDeviceID != "1111222233334444" || a.CheckinDeviceBrand != "Mac16,10" || a.CheckinDeviceType != "mac" {
+		t.Errorf("checkin device: id=%q brand=%q type=%q", a.CheckinDeviceID, a.CheckinDeviceBrand, a.CheckinDeviceType)
+	}
 }
 
 func TestParseFlat(t *testing.T) {
-	raw := []byte(`{"accessToken":"at","refreshToken":"rt","expiresAt":1753600000,"uid":"u2","nickname":"n2","machineId":"m1","deviceId":"d1"}`)
+	raw := []byte(`{"accessToken":"at","refreshToken":"rt","expiresAt":1753600000,"uid":"u2","nickname":"n2","machineId":"m1","deviceId":"d1","checkinDeviceId":"1111222233334444","checkinDeviceBrand":"90SB001GCD","checkinDeviceType":"windows"}`)
 	a, err := Parse(raw)
-	if err != nil || a.UID != "u2" || a.AccessToken != "at" || a.MachineID != "m1" || a.DeviceID != "d1" {
+	if err != nil || a.UID != "u2" || a.AccessToken != "at" || a.MachineID != "m1" || a.DeviceID != "d1" || a.CheckinDeviceID != "1111222233334444" || a.CheckinDeviceBrand != "90SB001GCD" || a.CheckinDeviceType != "windows" {
 		t.Fatalf("flat: %+v %v", a, err)
 	}
 }
@@ -60,7 +64,7 @@ func TestSaveAtomicRoundtripPreservesSOLOFields(t *testing.T) {
 	a := &Auth{
 		AccessToken: "at", RefreshToken: "rt", ExpiresAt: 1786805537,
 		Domain: "trae.cn", ApiHost: "https://api.trae.com.cn",
-		MachineID: "m123", DeviceID: "d456",
+		MachineID: "m123", DeviceID: "d456", CheckinDeviceID: "1111222233334444", CheckinDeviceBrand: "90SB001GCD", CheckinDeviceType: "windows",
 		UID: "u1", EnterpriseID: "e1", Nickname: "n1", FilePath: fp,
 	}
 	if err := a.SaveAtomic(); err != nil {
@@ -85,6 +89,9 @@ func TestSaveAtomicRoundtripPreservesSOLOFields(t *testing.T) {
 	}
 	if b.MachineID != "m123" || b.DeviceID != "d456" || b.ApiHost != "https://api.trae.com.cn" {
 		t.Errorf("SOLO fields lost: %+v", b)
+	}
+	if b.CheckinDeviceID != "1111222233334444" || b.CheckinDeviceBrand != "90SB001GCD" || b.CheckinDeviceType != "windows" {
+		t.Errorf("checkin device fields lost: %+v", b)
 	}
 }
 

--- a/internal/auth/checkin_device.go
+++ b/internal/auth/checkin_device.go
@@ -1,0 +1,147 @@
+// checkin_device.go 本机签到设备标识自动读取。
+//
+// 签到接口（/ug/checkin_credits/*）要求请求头带独立设备三件套
+// （x-device-id / x-device-brand / x-device-type），且与模型通道的
+// machineId/deviceId 不同。官方客户端（TRAE SOLO CN）把该设备 ID 以
+// "user_unique_id":"<16位数字>" 明文保存在 Chromium Local Storage
+// leveldb 里（mitm 抓包确认：leveldb 中的值与签到请求 x-device-id
+// 完全一致）。本文件负责在凭证缺少 checkinDeviceId 时从本机官方客户端
+// 自动读取，避免用户手工折腾；读取失败时由调用方明确报错并提示手动获取。
+package auth
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// userUniqueIDRe 匹配 leveldb 日志中的设备 ID 明文（10~20 位纯数字）。
+var userUniqueIDRe = regexp.MustCompile(`"user_unique_id":"(\d{10,20})"`)
+
+// scanFileMax 单个 leveldb 文件的读取上限（防御异常大文件，正常 .log/.ldb 远小于此）。
+const scanFileMax = 64 << 20
+
+// DetectLocalCheckinDevice 从本机已登录的 TRAE SOLO 官方客户端本地数据中
+// 读取签到设备标识三件套。找不到（未安装/未登录官方客户端，或不支持的
+// 平台）时 ok=false，由调用方决定跳过或要求手动填写。brand 为尽力探测，
+// 个别环境可能为空（签到结果校验会兜底暴露问题）。
+func DetectLocalCheckinDevice() (id, brand, typ string, ok bool) {
+	// 环境变量兜底开关：禁止探测本机客户端数据（测试/隐私敏感环境用）。
+	if os.Getenv("TW2A_DISABLE_CHECKIN_DETECT") != "" {
+		return "", "", "", false
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		typ = "mac"
+	case "windows":
+		typ = "windows"
+	default:
+		return "", "", "", false
+	}
+	for _, dir := range clientLeveldbDirs() {
+		if id, ok = scanUserUniqueID(dir); ok {
+			break
+		}
+	}
+	if !ok {
+		return "", "", "", false
+	}
+	if runtime.GOOS == "darwin" {
+		brand = detectBrandDarwin()
+	} else {
+		brand = detectBrandWindows()
+	}
+	return id, brand, typ, true
+}
+
+// clientLeveldbDirs 返回官方客户端 Local Storage leveldb 候选目录
+// （按优先级：SOLO CN 在前，兼容普通版 CN）。
+func clientLeveldbDirs() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		base := filepath.Join(home, "Library", "Application Support")
+		return []string{
+			filepath.Join(base, "TRAE SOLO CN", "Local Storage", "leveldb"),
+			filepath.Join(base, "TRAE CN", "Local Storage", "leveldb"),
+		}
+	case "windows":
+		roaming := os.Getenv("APPDATA")
+		if roaming == "" {
+			return nil
+		}
+		return []string{
+			filepath.Join(roaming, "TRAE SOLO CN", "Local Storage", "leveldb"),
+			filepath.Join(roaming, "TRAE CN", "Local Storage", "leveldb"),
+		}
+	}
+	return nil
+}
+
+// scanUserUniqueID 在 leveldb 目录中按修改时间从新到旧扫描 .log/.ldb
+// 文件，返回第一个命中的 user_unique_id。读失败/未命中返回 false。
+func scanUserUniqueID(dir string) (string, bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false
+	}
+	type f struct {
+		path    string
+		modTime int64
+	}
+	var files []f
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".log") && !strings.HasSuffix(name, ".ldb") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.Size() > scanFileMax {
+			continue
+		}
+		files = append(files, f{filepath.Join(dir, name), info.ModTime().UnixNano()})
+	}
+	// 新的在前：设备 ID 可能随客户端重装变化，以最新写入为准。
+	sort.Slice(files, func(i, j int) bool { return files[i].modTime > files[j].modTime })
+	for _, file := range files {
+		raw, err := os.ReadFile(file.path)
+		if err != nil {
+			continue
+		}
+		if m := userUniqueIDRe.FindSubmatch(raw); m != nil {
+			return string(m[1]), true
+		}
+	}
+	return "", false
+}
+
+// detectBrandDarwin 读 Mac 机型（如 "Mac16,10"），与官方客户端
+// x-device-brand 一致。失败返回空串。
+func detectBrandDarwin() string {
+	out, err := exec.Command("sysctl", "-n", "hw.model").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// detectBrandWindows 读主板型号（官方 Windows 客户端 x-device-brand
+// 即主板 product 名）。wmic 已弃用，走 PowerShell CIM；失败返回空串。
+func detectBrandWindows() string {
+	out, err := exec.Command("powershell", "-NoProfile", "-Command",
+		"(Get-CimInstance Win32_BaseBoard).Product").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/auth/checkin_device_test.go
+++ b/internal/auth/checkin_device_test.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestScanUserUniqueID(t *testing.T) {
+	dir := t.TempDir()
+	// 旧文件里的旧 ID 与新文件里的新 ID：应以最新修改的文件为准。
+	old := filepath.Join(dir, "000001.ldb")
+	newF := filepath.Join(dir, "000002.log")
+	if err := os.WriteFile(old, []byte(`{"user_unique_id":"1111111111111111","timestamp":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newF, []byte(`junk{"user_unique_id":"2222222222222222","timestamp":2}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(old, past, past); err != nil {
+		t.Fatal(err)
+	}
+	id, ok := scanUserUniqueID(dir)
+	if !ok || id != "2222222222222222" {
+		t.Fatalf("got (%q,%v), want (2222222222222222,true)", id, ok)
+	}
+}
+
+func TestScanUserUniqueIDMiss(t *testing.T) {
+	// 目录不存在
+	if _, ok := scanUserUniqueID(filepath.Join(t.TempDir(), "nope")); ok {
+		t.Fatal("missing dir should miss")
+	}
+	// 目录存在但没有匹配内容
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "000001.log"), []byte(`{"other":"x"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := scanUserUniqueID(dir); ok {
+		t.Fatal("no user_unique_id should miss")
+	}
+	// 非数字 ID 不匹配
+	dir2 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir2, "000001.log"), []byte(`{"user_unique_id":"abc-def"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := scanUserUniqueID(dir2); ok {
+		t.Fatal("non-numeric id should miss")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"traework2api/internal/auth"
 	"traework2api/internal/pool"
 	"traework2api/internal/upstream"
 )
@@ -99,10 +100,22 @@ func (s *Scheduler) RunCheckinNow() {
 		}
 		// 签到（status → 未签到则 claim）
 		if a.CheckinDeviceID == "" {
-			// 凭证缺少独立签到设备标识：多账号签到要求各账号使用不同的
-			// 设备 ID，缺字段时明确跳过并说明，不发无设备头的无效请求，
-			// 也不生成随机假 ID（上游无法识别，签到永远不会生效）。
-			log.Printf("checkin %s: skip, missing checkinDeviceId（签到需独立设备ID，多账号须各不相同；请重新导入含 checkinDeviceId/checkinDeviceBrand/checkinDeviceType 的凭证）", st.UID)
+			// 凭证缺独立签到设备标识时，尝试从本机已登录的官方客户端自动读取
+			// 并写回凭证（Docker 容器内读不到宿主机客户端数据，会走到下面的跳过分支）。
+			if id, brand, typ, ok := auth.DetectLocalCheckinDevice(); ok {
+				a.CheckinDeviceID, a.CheckinDeviceBrand, a.CheckinDeviceType = id, brand, typ
+				if err := a.SaveAtomic(); err != nil {
+					log.Printf("checkin %s: 自动读取签到设备ID成功但写回失败: %v", st.UID, err)
+				} else {
+					log.Printf("checkin %s: 已从本机官方客户端自动读取签到设备ID并写回凭证", st.UID)
+				}
+			}
+		}
+		if a.CheckinDeviceID == "" {
+			// 凭证缺少独立签到设备标识且本机检测不到官方客户端：多账号签到
+			// 要求各账号使用不同的设备 ID，缺字段时明确跳过并说明，不发无设备头
+			// 的无效请求，也不生成随机假 ID（上游无法识别，签到永远不会生效）。
+			log.Printf("checkin %s: skip, 缺签到设备ID且本机未检测到官方客户端（在已登录官方客户端的机器上跑 signin.sh 可自动读取并写回凭证；手动获取见 README「签到设备ID」）", st.UID)
 		} else {
 			checkedIn, _, enable, err := s.cfg.Upstream.CheckinStatus(a)
 			if err != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -98,17 +98,31 @@ func (s *Scheduler) RunCheckinNow() {
 			continue
 		}
 		// 签到（status → 未签到则 claim）
-		checkedIn, _, enable, err := s.cfg.Upstream.CheckinStatus(a)
-		if err != nil {
-			log.Printf("checkin status %s: %v", st.UID, err)
-		} else if !checkedIn && enable {
-			if err := s.cfg.Upstream.CheckinClaim(a); err != nil {
-				log.Printf("checkin claim %s: %v", st.UID, err)
-			} else {
-				log.Printf("checkin %s: ok", st.UID)
+		if a.CheckinDeviceID == "" {
+			// 凭证缺少独立签到设备标识：多账号签到要求各账号使用不同的
+			// 设备 ID，缺字段时明确跳过并说明，不发无设备头的无效请求，
+			// 也不生成随机假 ID（上游无法识别，签到永远不会生效）。
+			log.Printf("checkin %s: skip, missing checkinDeviceId（签到需独立设备ID，多账号须各不相同；请重新导入含 checkinDeviceId/checkinDeviceBrand/checkinDeviceType 的凭证）", st.UID)
+		} else {
+			checkedIn, _, enable, err := s.cfg.Upstream.CheckinStatus(a)
+			if err != nil {
+				log.Printf("checkin status %s: %v", st.UID, err)
+			} else if !checkedIn && enable {
+				if err := s.cfg.Upstream.CheckinClaim(a); err != nil {
+					log.Printf("checkin claim %s: %v", st.UID, err)
+				} else {
+					verified, _, _, err := s.cfg.Upstream.CheckinStatus(a)
+					if err != nil {
+						log.Printf("checkin verify %s: %v", st.UID, err)
+					} else if !verified {
+						log.Printf("checkin verify %s: status still unchecked", st.UID)
+					} else {
+						log.Printf("checkin %s: ok", st.UID)
+					}
+				}
+			} else if checkedIn {
+				log.Printf("checkin %s: already checked in", st.UID)
 			}
-		} else if checkedIn {
-			log.Printf("checkin %s: already checked in", st.UID)
 		}
 		// 查积分 + 解冻
 		remain, err := s.cfg.Upstream.UserEntUsage(a)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -150,9 +150,10 @@ func TestRunCheckinDoesNotLogSuccessWhenStatusDoesNotChange(t *testing.T) {
 	}
 }
 
-// 凭证缺 checkinDeviceId 时必须跳过签到并打印明确提示，
-// 不发无设备头的无效请求，也不生成随机假 ID。
+// 凭证缺 checkinDeviceId 且无法从本机官方客户端自动读取时，
+// 必须跳过签到并打印明确提示，不发无设备头的无效请求，也不生成随机假 ID。
 func TestRunCheckinSkipsMissingCheckinDeviceID(t *testing.T) {
+	t.Setenv("TW2A_DISABLE_CHECKIN_DETECT", "1") // 隔离本机官方客户端数据，保持用例 hermetic
 	f := &fakeUpstream{resourceRemain: 500}
 	srv := f.server()
 	defer srv.Close()
@@ -171,7 +172,7 @@ func TestRunCheckinSkipsMissingCheckinDeviceID(t *testing.T) {
 		t.Errorf("no upstream checkin calls expected, status=%d claim=%d",
 			f.checkinCalls.Load(), f.claimCalls.Load())
 	}
-	if !strings.Contains(logs.String(), "missing checkinDeviceId") {
+	if !strings.Contains(logs.String(), "缺签到设备ID") {
 		t.Fatalf("missing skip hint: %s", logs.String())
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -47,14 +48,16 @@ type fakeUpstream struct {
 	claimCalls     atomic.Int32
 	refreshCalls   atomic.Int32
 	resourceRemain int64
+	verifyChecked  bool
 }
 
 func (f *fakeUpstream) server() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/checkin_credits/status"):
-			f.checkinCalls.Add(1)
-			w.Write([]byte(`{"checked_in":false,"credits":200,"enable":true}`))
+			call := f.checkinCalls.Add(1)
+			checked := f.verifyChecked && call > 1
+			w.Write([]byte(`{"checked_in":` + jsonBool(checked) + `,"credits":200,"enable":true}`))
 		case strings.HasSuffix(r.URL.Path, "/checkin_credits/claim"):
 			f.claimCalls.Add(1)
 			w.Write([]byte(`{"code":0,"message":"success"}`))
@@ -71,6 +74,11 @@ func (f *fakeUpstream) server() *httptest.Server {
 }
 
 func jsonI64(v int64) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func jsonBool(v bool) string {
 	b, _ := json.Marshal(v)
 	return string(b)
 }
@@ -93,18 +101,18 @@ func newTestScheduler(f *fakeUpstream, p *pool.Pool, srv *httptest.Server) *Sche
 }
 
 func TestRunCheckinReenablesCoolingAccount(t *testing.T) {
-	f := &fakeUpstream{resourceRemain: 500}
+	f := &fakeUpstream{resourceRemain: 500, verifyChecked: true}
 	srv := f.server()
 	defer srv.Close()
 
 	p := pool.New("")
-	a := &auth.Auth{UID: "u1", AccessToken: "at", RefreshToken: "rt", ExpiresAt: 9999999999}
+	a := &auth.Auth{UID: "u1", AccessToken: "at", RefreshToken: "rt", ExpiresAt: 9999999999, CheckinDeviceID: "cd-u1"}
 	p.Add(a)
 	p.Cooldown("u1", pool.CoolPlan, time.Hour, "plan limit")
 
 	s := newTestScheduler(f, p, srv)
 	s.RunCheckinNow()
-	if f.checkinCalls.Load() != 1 {
+	if f.checkinCalls.Load() != 2 {
 		t.Errorf("checkin status calls=%d", f.checkinCalls.Load())
 	}
 	if f.claimCalls.Load() != 1 {
@@ -116,6 +124,55 @@ func TestRunCheckinReenablesCoolingAccount(t *testing.T) {
 	}
 	if st.Credits != 500 {
 		t.Errorf("credits=%d want 500", st.Credits)
+	}
+}
+
+func TestRunCheckinDoesNotLogSuccessWhenStatusDoesNotChange(t *testing.T) {
+	f := &fakeUpstream{resourceRemain: 500}
+	srv := f.server()
+	defer srv.Close()
+
+	p := pool.New("")
+	p.Add(&auth.Auth{UID: "u1", AccessToken: "at", RefreshToken: "rt", ExpiresAt: 9999999999, CheckinDeviceID: "cd-u1"})
+
+	var logs strings.Builder
+	old := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(old)
+
+	s := newTestScheduler(f, p, srv)
+	s.RunCheckinNow()
+	if strings.Contains(logs.String(), "checkin u1: ok") {
+		t.Fatalf("false success log: %s", logs.String())
+	}
+	if !strings.Contains(logs.String(), "checkin verify u1") {
+		t.Fatalf("missing verification failure: %s", logs.String())
+	}
+}
+
+// 凭证缺 checkinDeviceId 时必须跳过签到并打印明确提示，
+// 不发无设备头的无效请求，也不生成随机假 ID。
+func TestRunCheckinSkipsMissingCheckinDeviceID(t *testing.T) {
+	f := &fakeUpstream{resourceRemain: 500}
+	srv := f.server()
+	defer srv.Close()
+
+	p := pool.New("")
+	p.Add(&auth.Auth{UID: "u1", AccessToken: "at", RefreshToken: "rt", ExpiresAt: 9999999999})
+
+	var logs strings.Builder
+	old := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(old)
+
+	s := newTestScheduler(f, p, srv)
+	s.RunCheckinNow()
+	if f.checkinCalls.Load() != 0 || f.claimCalls.Load() != 0 {
+		t.Errorf("no upstream checkin calls expected, status=%d claim=%d",
+			f.checkinCalls.Load(), f.claimCalls.Load())
+	}
+	if !strings.Contains(logs.String(), "missing checkinDeviceId") {
+		t.Fatalf("missing skip hint: %s", logs.String())
 	}
 }
 

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -331,14 +331,22 @@ func (c *Client) CheckinStatus(a *auth.Auth) (checkedIn bool, credits int64, ena
 		return false, 0, false, err
 	}
 	var resp struct {
-		CheckedIn bool  `json:"checked_in"`
-		Credits   int64 `json:"credits"`
-		Enable    bool  `json:"enable"`
+		CheckedIn *bool  `json:"checked_in"`
+		Credits   int64  `json:"credits"`
+		Enable    *bool  `json:"enable"`
+		Code      *int   `json:"code"`
+		Message   string `json:"message"`
 	}
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return false, 0, false, fmt.Errorf("checkin status parse: %w", err)
 	}
-	return resp.CheckedIn, resp.Credits, resp.Enable, nil
+	if resp.Code != nil && *resp.Code != 0 {
+		return false, 0, false, fmt.Errorf("checkin status: code=%d message=%s", *resp.Code, resp.Message)
+	}
+	if resp.CheckedIn == nil || resp.Enable == nil {
+		return false, 0, false, fmt.Errorf("checkin status: missing checked_in or enable")
+	}
+	return *resp.CheckedIn, resp.Credits, *resp.Enable, nil
 }
 
 // CheckinClaim 执行签到。
@@ -348,11 +356,27 @@ func (c *Client) CheckinClaim(a *auth.Auth) error {
 		return err
 	}
 	UgHeaders(req, a)
-	_, err = c.doJSON(req)
-	return err
+	data, err := c.doJSON(req)
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		Code    *int   `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("checkin claim parse: %w", err)
+	}
+	if resp.Code != nil && *resp.Code != 0 {
+		return fmt.Errorf("checkin claim: code=%d message=%s", *resp.Code, resp.Message)
+	}
+	return nil
 }
 
-// UserEntUsage 聚合积分（ide_user_ent_usage 的 credits_limit 求和）。
+// UserEntUsage 聚合剩余积分（ide_user_ent_usage）。
+// 上游每个包的 quota.credits_limit 为总额度，usage.credits_amount 为已消耗，
+// 剩余 = Σ(credits_limit) − Σ(usage.credits_amount)。
+// 旧实现只求和 credits_limit，导致把总额度当剩余且永不变动，故修正。
 func (c *Client) UserEntUsage(a *auth.Auth) (remain int64, err error) {
 	req, err := http.NewRequest(http.MethodPost, c.ugBase()+EpEntUsage, bytes.NewReader([]byte("{}")))
 	if err != nil {
@@ -364,20 +388,30 @@ func (c *Client) UserEntUsage(a *auth.Auth) (remain int64, err error) {
 		return 0, err
 	}
 	var resp struct {
-		IsCreditsBilling bool `json:"is_credits_billing"`
+		IsCreditsBilling        bool `json:"is_credits_billing"`
 		UserEntitlementPackList []struct {
 			EntitlementBaseInfo struct {
 				Quota struct {
 					CreditsLimit int64 `json:"credits_limit"`
 				} `json:"quota"`
 			} `json:"entitlement_base_info"`
+			Usage struct {
+				CreditsAmount float64 `json:"credits_amount"`
+			} `json:"usage"`
 		} `json:"user_entitlement_pack_list"`
 	}
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return 0, fmt.Errorf("ent usage parse: %w", err)
 	}
+	var limit, used float64
 	for _, p := range resp.UserEntitlementPackList {
-		remain += p.EntitlementBaseInfo.Quota.CreditsLimit
+		limit += float64(p.EntitlementBaseInfo.Quota.CreditsLimit)
+		used += p.Usage.CreditsAmount
+	}
+	// 剩余不能为负；API 仅提供总额度与已用量，无独立剩余字段。
+	remain = int64(limit - used)
+	if remain < 0 {
+		remain = 0
 	}
 	return remain, nil
 }

--- a/internal/upstream/client_test.go
+++ b/internal/upstream/client_test.go
@@ -181,7 +181,7 @@ func TestChatStreamSendsHeadersAndRewritesBody(t *testing.T) {
 	if gotAuth != "Cloud-IDE-JWT at" || gotUID != "u1" {
 		t.Errorf("headers: auth=%q uid=%q", gotAuth, gotUID)
 	}
-	if gotAppID != AppID || gotIdeVer != "0.1.43" {
+	if gotAppID != AppID || gotIdeVer != IdeVersion {
 		t.Errorf("app headers: appid=%q idever=%q", gotAppID, gotIdeVer)
 	}
 	if !bytes.Contains(gotBody, []byte(`"stream":true`)) || !bytes.Contains(gotBody, []byte(`"function":"solo_work_lite"`)) {
@@ -248,16 +248,16 @@ func TestUserEntUsageAggregation(t *testing.T) {
 	}
 }
 
-func TestCheckinStatusAndClaim(t *testing.T) {
+func TestCheckinStatusSendsOfficialDeviceHeaders(t *testing.T) {
 	var path string
 	c := testClient(func(r *http.Request) (*http.Response, error) {
 		path = r.URL.Path
-		if r.Header.Get("X-User-Region") != "CN" {
-			return nil, errors.New("missing X-User-Region")
+		if r.Header.Get("X-Device-Id") != "1111222233334444" || r.Header.Get("X-Device-Brand") != "90SB001GCD" || r.Header.Get("X-Device-Type") != "windows" {
+			return nil, errors.New("missing official device headers")
 		}
 		return jsonResp(200, `{"checked_in":false,"credits":200,"enable":true}`), nil
 	})
-	checkedIn, credits, enable, err := c.CheckinStatus(&auth.Auth{AccessToken: "at"})
+	checkedIn, credits, enable, err := c.CheckinStatus(&auth.Auth{AccessToken: "at", DeviceID: "model-device", CheckinDeviceID: "1111222233334444", CheckinDeviceBrand: "90SB001GCD", CheckinDeviceType: "windows"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,5 +266,47 @@ func TestCheckinStatusAndClaim(t *testing.T) {
 	}
 	if path != EpCheckinStatus {
 		t.Errorf("path=%s", path)
+	}
+}
+
+func TestCheckinStatusRejectsBusinessFailure(t *testing.T) {
+	c := testClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResp(200, `{"code":1002,"message":"device unavailable"}`), nil
+	})
+	_, _, _, err := c.CheckinStatus(&auth.Auth{AccessToken: "at"})
+	if err == nil || !strings.Contains(err.Error(), "device unavailable") {
+		t.Fatalf("error=%v want status business failure", err)
+	}
+}
+
+func TestCheckinStatusRejectsMissingStateFields(t *testing.T) {
+	c := testClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResp(200, `{"code":0,"message":"success"}`), nil
+	})
+	_, _, _, err := c.CheckinStatus(&auth.Auth{AccessToken: "at"})
+	if err == nil || !strings.Contains(err.Error(), "missing checked_in or enable") {
+		t.Fatalf("error=%v want protocol failure", err)
+	}
+}
+
+func TestCheckinClaimRejectsBusinessFailure(t *testing.T) {
+	c := testClient(func(r *http.Request) (*http.Response, error) {
+		return jsonResp(200, `{"code":1001,"message":"device rejected"}`), nil
+	})
+	err := c.CheckinClaim(&auth.Auth{AccessToken: "at"})
+	if err == nil || !strings.Contains(err.Error(), "device rejected") {
+		t.Fatalf("error=%v want business failure", err)
+	}
+}
+
+func TestCheckinClaimAcceptsBusinessSuccess(t *testing.T) {
+	c := testClient(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != EpCheckinClaim {
+			return nil, errors.New("wrong path: " + r.URL.Path)
+		}
+		return jsonResp(200, `{"code":0,"message":"success"}`), nil
+	})
+	if err := c.CheckinClaim(&auth.Auth{AccessToken: "at"}); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/upstream/headers.go
+++ b/internal/upstream/headers.go
@@ -51,8 +51,14 @@ func UgHeaders(req *http.Request, a *auth.Auth) {
 	req.Header.Set("User-Agent", clientUA)
 	req.Header.Set("Authorization", "Cloud-IDE-JWT "+a.JWT()) // 读锁快照
 	req.Header.Set("X-User-Region", "CN")
-	if a.DeviceID != "" {
-		req.Header.Set("X-Device-Id", a.DeviceID)
+	if a.CheckinDeviceID != "" {
+		req.Header.Set("X-Device-Id", a.CheckinDeviceID)
+	}
+	if a.CheckinDeviceBrand != "" {
+		req.Header.Set("X-Device-Brand", a.CheckinDeviceBrand)
+	}
+	if a.CheckinDeviceType != "" {
+		req.Header.Set("X-Device-Type", a.CheckinDeviceType)
 	}
 }
 


### PR DESCRIPTION
修复 TRAE SOLO CN 自动签到的两个问题：签到结果此前存在"假成功"，且签到请求复用了模型通道的设备标识。

## 问题

1. **签到假成功**：`claim` 接口返回 HTTP 200 就判定成功，但上游业务码 `code != 0` 时签到实际并未生效。
2. **设备标识串用**：签到请求复用了模型通道的 `deviceId`，与官方客户端真实签到请求的请求头不一致。

## 改动

### fix: 签到结果校验 + 独立签到设备指纹

- `cmd/signin`：claim 后用 `CheckinStatus` 复核，未生效明确报 `FAIL`（不再假 OK）
- `internal/auth`：新增 `CheckinDeviceID` / `Brand` / `Type` 三个字段及解析、落盘（auth 文件 auth 段新增 `checkinDeviceId` / `checkinDeviceBrand` / `checkinDeviceType`）
- `internal/upstream/headers`：签到请求改用 `CheckinDeviceID` / `Brand` / `Type` 发送 `X-Device-Id` / `X-Device-Brand` / `X-Device-Type`，与模型通道的 `deviceId` 解耦
- `internal/upstream/client`：`CheckinStatus` 严格解析 `code` / `message`；`CheckinClaim` 检查业务错误码（上游 200 但 `code != 0` 视为失败）；`UserEntUsage` 修正为 剩余 = Σlimit − Σused
- `internal/scheduler`：自动签到后同样做结果校验
- `cmd/server`：启动即刷新一次 token + 签到 + 积分，避免 `state.json` 为空时长期显示 0

### feat: 缺签到设备ID时自动读取本机官方客户端设备标识

凭证缺 `checkinDeviceId` 时，`signin` CLI 与调度器先从本机已登录的 TRAE SOLO 官方客户端 Local Storage leveldb 读取 `user_unique_id`（抓包确认与签到 `x-device-id` 一致），并写回凭证文件供容器内调度器复用；brand 按平台尽力探测（darwin `sysctl hw.model` / windows CIM baseboard）。探测不到时保持明确跳过 + 提示。

- 新增 `TW2A_DISABLE_CHECKIN_DETECT=1` 兜底开关（隐私敏感环境可关闭本机探测）
- CLI 增加多账号共用同一签到设备ID 的关联警告
- README 补「签到设备ID」节，含第二台设备的手动获取命令

## 兼容性

- 凭证已含 `checkinDeviceId` → 直接沿用，行为不变
- 凭证缺失 + 本机装有官方客户端并登录过 → 首次运行自动读取并写回，后续复用
- 凭证缺失 + 未安装客户端 → 明确报 `FAIL` 并提示手动获取（不发无效请求，也不生成随机假 ID，随机值上游无法识别，签到永远不会生效）

## 隐私

改动只读取本机客户端 Local Storage 中的设备标识用于构造请求头，不上传任何本地数据；所有凭证 / 数据文件均在 `.gitignore` 排除范围内，本次提交不含 `auths/` `data/` `.env`。可用 `TW2A_DISABLE_CHECKIN_DETECT=1` 完全关闭探测。

## 测试

本地多账号环境已验证：签到状态复核生效，缺设备ID 时自动探测补齐，多账号共用 ID 正确告警。
